### PR TITLE
Added display date feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ There are four configurable options:
 | reflection | set `false` to turn off reflection effect. | `true` |
 | timeFormat | `12` hour or `24` hour display. | `24` |
 | displaySeconds | `true` for a 6-digit clock or `false` for a 4-digit clock. | `true` |
+| displayDateInterval | integer value >=0 and <=5 to set how often the date will be displayed in minutes (for example 2 is every other minute), 0 means do not display the date. | `2` |
+| displayDateTime | integer value >0 and <=3 to set the time the date will be displayed at the start of the minute. | `3` |
 
 Sample config file (default):
 ```js
@@ -29,6 +31,8 @@ var config = {
         reflection: true,
         timeFormat: 24,
         displaySeconds: true,
+        displayDateInterval: 2,
+        displayDateTime: 3,
       }
     }
   ]

--- a/css/default.css
+++ b/css/default.css
@@ -36,7 +36,7 @@
 	width: 80px;
 }
 
-.tube-medium, {
+.tube-medium {
 	width: 120px;
 }
 


### PR DESCRIPTION
Added a display date feature (sorry only non-US format) at the beginning of specific minutes in the hour
Two settings have been added to control this feature when (displayDateInterval, every x minutes) and how long (displayDateTime, for y seconds). displayDateInterval 0 is used if you don't want to display the date, otherwise it should be between 1 and 5. DisplayDateTime should be between 1 and 3.